### PR TITLE
Use better currency provider: more currencies, more frequent updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebro-converter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Cerebro plugin for converting units and currencies",
   "license": "MIT",
   "repository": "KELiON/cerebro-converter",

--- a/src/currency/getUrl.js
+++ b/src/currency/getUrl.js
@@ -3,10 +3,8 @@ const { CURRENCIES } = require('./constants.js')
 
 /**
  * Build url to get exchange rates
- * @param  {String} base Base currency
  * @return {String} url
  */
-module.exports = (base) => {
-  const symbols = CURRENCIES.map(cur => cur.toUpperCase()).join(',')
-  return `https://api.fixer.io/latest?base=${base}&symbols=${symbols}`
+module.exports = () => {
+  return "https://www.mycurrency.net/service/rates"
 }


### PR DESCRIPTION
Fixes #13.

Notes:
- There is no need to make URL or cache expiration dependent on base currency, linear convertor doesn't care about the base currency. Just play around with current code and you will see, even though the API always returns rates relative to USD, it doesn't matter for conversion.
- Since this API refreshes every 2 hours and doesn't have a limit on frequency of calls, we can make use of this and make cache expire after 2 hours instead of 24 hours. This is not perfectly precise, as the service doesn't tell us exactly when it refreshed cache last time, but that's still OK.

@KELiON please have a look soon 🙏 